### PR TITLE
fix: correctly destroy socket when destroy function is called on

### DIFF
--- a/src/client/client.socket.ts
+++ b/src/client/client.socket.ts
@@ -22,7 +22,7 @@ export const wrapSocket = (socket: Socket) =>
       debug('responseStream.connect event');
       resolve(responseStream);
     });
-    socket.on('close', () => { console.error('socket#close'); reject(); });
+    socket.on('close', () => { debug('socket#close'); reject(); });
     socket.on('end', () => { console.error('socket#end'); reject(); });
   });
 

--- a/src/client/client.socket.ts
+++ b/src/client/client.socket.ts
@@ -54,6 +54,11 @@ export class CommandResponseStream extends Duplex {
     this.isAuthenticated = false;
   };
 
+  // Probably triggered by Duplex class
+  _destroy() {
+    this._socket.destroy();
+  }
+
   _read(size: number): void {
     this._readPaused = false;
     debug('stream#_read', size);


### PR DESCRIPTION
Hello!

While doing integration test, the node process is not correctly closed at the end because the client is not destroy (and so the TCP connection is kept open).

By editing local module
- without: server is not closed
- with: process closes automatically at the end of the test series

```
[WTF Node?] open handles:
- File descriptors: (note: stdio always exists)
  - fd 2 (tty) (stdio)
  - fd 1 (tty) (stdio)
  - fd 0 (tty)
- Sockets:
  - ::1:65251 -> ::1:10002
    - Listeners:
      - connect: Readable.on @ node:internal/streams/readable:1126
```
